### PR TITLE
Added robust means of loading animation 

### DIFF
--- a/games/Better-Boids-Game/Better-Boids.html
+++ b/games/Better-Boids-Game/Better-Boids.html
@@ -124,7 +124,13 @@
           "game-loading-content-img"
         );
 
-        gameLoadingContentImg.addEventListener("animationiteration", () => {
+        let hasLoadedAnimPlayed = false;
+        function playLoadedAnim(gameLoadingContentImg, gameLoadInOverlay) {
+          if (hasLoadedAnimPlayed) {
+            console.log("played already");
+            return;
+          }
+
           gameLoadingContentImg.classList.remove(
             "game-loading-content-play-loading-anim"
           );
@@ -132,7 +138,32 @@
             "game-loading-content-play-loaded-anim"
           );
           gameLoadInOverlay.classList.add("game-load-in-overlay-play-anim");
-        });
+
+          // Mark the animation as played
+          hasLoadedAnimPlayed = true;
+        }
+
+        // Set a timeout to call the desired function after the specified duration,
+        // if the event listeners for animationiteration() do not catch it.
+        const timeout = setTimeout(() => {
+          console.log("Timeout reached, ending loading anim");
+          playLoadedAnim(gameLoadingContentImg, gameLoadInOverlay);
+        }, 3000); // ms
+
+        gameLoadingContentImg.addEventListener(
+          "animationiteration",
+          function () {
+            playLoadedAnim(gameLoadingContentImg, gameLoadInOverlay);
+            clearTimeout(timeout); // Clear the timeout since the event fired
+          }
+        );
+        gameLoadingContentImg.addEventListener(
+          "webkitAnimationIteration", // For Safari pre-9 or other browser compatibility
+          function () {
+            playLoadedAnim(gameLoadingContentImg, gameLoadInOverlay);
+            clearTimeout(timeout); // Clear the timeout since the event fired
+          }
+        );
 
         // Apply click animation to all <a> elements
         const links = document.querySelectorAll("a");

--- a/games/Better-Boids-Game/Better-Boids.html
+++ b/games/Better-Boids-Game/Better-Boids.html
@@ -99,11 +99,12 @@
     <!-- Call JS functions (using module so that we can import and call modules) -->
     <script type="module">
       // Import modules
-      import { LaunchGame } from "./js/game.js";
-      import { addBoidSettings } from "./js/boid-settings.js";
-      import { addInfoBox } from "../Better-Boids-Game/js/info-box.js";
-      import { createGameHeader } from "../Shared-Game-Assets/js/game-header.js";
+      import { LaunchGame } from "/games/Better-Boids-Game/js/game.js";
+      import { addBoidSettings } from "/games/Better-Boids-Game/js/boid-settings.js";
+      import { addInfoBox } from "/games/Better-Boids-Game/js/info-box.js";
+      import { createGameHeader } from "/games/Shared-Game-Assets/js/game-header.js";
       import { addClickAnimation } from "/Shared-General-Assets/js/click-animation.js";
+      import { gamesEntryHtmlLoadingScreenAnimations } from "/games/Shared-Game-Assets/js/loading.js";
 
       // Wait for window (aka all content) to load in before calling functions
       window.onload = function () {
@@ -117,53 +118,7 @@
         LaunchGame();
 
         // Play loading anim after a good amount has loaded in
-        const gameLoadInOverlay = document.getElementById(
-          "game-load-in-overlay"
-        );
-        const gameLoadingContentImg = document.getElementById(
-          "game-loading-content-img"
-        );
-
-        let hasLoadedAnimPlayed = false;
-        function playLoadedAnim(gameLoadingContentImg, gameLoadInOverlay) {
-          if (hasLoadedAnimPlayed) {
-            console.log("played already");
-            return;
-          }
-
-          gameLoadingContentImg.classList.remove(
-            "game-loading-content-play-loading-anim"
-          );
-          gameLoadingContentImg.classList.add(
-            "game-loading-content-play-loaded-anim"
-          );
-          gameLoadInOverlay.classList.add("game-load-in-overlay-play-anim");
-
-          // Mark the animation as played
-          hasLoadedAnimPlayed = true;
-        }
-
-        // Set a timeout to call the desired function after the specified duration,
-        // if the event listeners for animationiteration() do not catch it.
-        const timeout = setTimeout(() => {
-          console.log("Timeout reached, ending loading anim");
-          playLoadedAnim(gameLoadingContentImg, gameLoadInOverlay);
-        }, 3000); // ms
-
-        gameLoadingContentImg.addEventListener(
-          "animationiteration",
-          function () {
-            playLoadedAnim(gameLoadingContentImg, gameLoadInOverlay);
-            clearTimeout(timeout); // Clear the timeout since the event fired
-          }
-        );
-        gameLoadingContentImg.addEventListener(
-          "webkitAnimationIteration", // For Safari pre-9 or other browser compatibility
-          function () {
-            playLoadedAnim(gameLoadingContentImg, gameLoadInOverlay);
-            clearTimeout(timeout); // Clear the timeout since the event fired
-          }
-        );
+        gamesEntryHtmlLoadingScreenAnimations();
 
         // Apply click animation to all <a> elements
         const links = document.querySelectorAll("a");

--- a/games/Flip-Tile-Game/Flip-Tile.html
+++ b/games/Flip-Tile-Game/Flip-Tile.html
@@ -100,10 +100,11 @@
     <!-- Call JS functions (using module so that we can import and call modules) -->
     <script type="module">
       // Import modules
-      import { LaunchGame } from "./js/game.js";
-      import { initUI } from "./js/init-ui.js";
-      import { createGameHeader } from "../Shared-Game-Assets/js/game-header.js";
+      import { LaunchGame } from "/games/Flip-Tile-Game/js/game.js";
+      import { initUI } from "/games/Flip-Tile-Game/js/init-ui.js";
+      import { createGameHeader } from "/games/Shared-Game-Assets/js/game-header.js";
       import { addClickAnimation } from "/Shared-General-Assets/js/click-animation.js";
+      import { gamesEntryHtmlLoadingScreenAnimations } from "/games/Shared-Game-Assets/js/loading.js";
 
       // Wait for window (aka all content) to load in before calling functions
       window.onload = function () {
@@ -117,22 +118,7 @@
         LaunchGame();
 
         // Play loading anim after a good amount has loaded in
-        const gameLoadInOverlay = document.getElementById(
-          "game-load-in-overlay"
-        );
-        const gameLoadingContentImg = document.getElementById(
-          "game-loading-content-img"
-        );
-
-        gameLoadingContentImg.addEventListener("animationiteration", () => {
-          gameLoadingContentImg.classList.remove(
-            "game-loading-content-play-loading-anim"
-          );
-          gameLoadingContentImg.classList.add(
-            "game-loading-content-play-loaded-anim"
-          );
-          gameLoadInOverlay.classList.add("game-load-in-overlay-play-anim");
-        });
+        gamesEntryHtmlLoadingScreenAnimations();
 
         // Apply click animation to all <a> elements
         const links = document.querySelectorAll("a");

--- a/games/Generic-Game-Blueprint/Game-Name.html
+++ b/games/Generic-Game-Blueprint/Game-Name.html
@@ -97,9 +97,10 @@
     <!-- Call JS functions (using module so that we can import and call modules) -->
     <script type="module">
       // Import modules
-      import { LaunchGame } from "./js/game.js";
-      import { createGameHeader } from "../Shared-Game-Assets/js/game-header.js";
+      import { LaunchGame } from "/games/Generic-Game-Blueprint/js/game.js";
+      import { createGameHeader } from "/games/Shared-Game-Assets/js/game-header.js";
       import { addClickAnimation } from "/Shared-General-Assets/js/click-animation.js";
+      import { gamesEntryHtmlLoadingScreenAnimations } from "/games/Shared-Game-Assets/js/loading.js";
 
       // Wait for window (aka all content) to load in before calling functions
       window.onload = function () {
@@ -116,22 +117,7 @@
         // ...
 
         // Play loading anim after a good amount has loaded in
-        const gameLoadInOverlay = document.getElementById(
-          "game-load-in-overlay"
-        );
-        const gameLoadingContentImg = document.getElementById(
-          "game-loading-content-img"
-        );
-
-        gameLoadingContentImg.addEventListener("animationiteration", () => {
-          gameLoadingContentImg.classList.remove(
-            "game-loading-content-play-loading-anim"
-          );
-          gameLoadingContentImg.classList.add(
-            "game-loading-content-play-loaded-anim"
-          );
-          gameLoadInOverlay.classList.add("game-load-in-overlay-play-anim");
-        });
+        gamesEntryHtmlLoadingScreenAnimations();
 
         // Apply click animation to all <a> elements last
         const links = document.querySelectorAll("a");

--- a/games/Shared-Game-Assets/js/loading.js
+++ b/games/Shared-Game-Assets/js/loading.js
@@ -1,0 +1,53 @@
+/**
+ * @module Loading
+ *
+ * @author Shane Bonkowski
+ */
+
+/**
+ * Handles animations for the entry loading screen for a game html file.
+ */
+export function gamesEntryHtmlLoadingScreenAnimations() {
+  const gameLoadInOverlay = document.getElementById("game-load-in-overlay");
+  const gameLoadingContentImg = document.getElementById(
+    "game-loading-content-img"
+  );
+
+  let hasLoadedAnimPlayed = false;
+  function playLoadedAnim(gameLoadingContentImg, gameLoadInOverlay) {
+    if (hasLoadedAnimPlayed) {
+      console.log("played already");
+      return;
+    }
+
+    gameLoadingContentImg.classList.remove(
+      "game-loading-content-play-loading-anim"
+    );
+    gameLoadingContentImg.classList.add(
+      "game-loading-content-play-loaded-anim"
+    );
+    gameLoadInOverlay.classList.add("game-load-in-overlay-play-anim");
+
+    // Mark the animation as played
+    hasLoadedAnimPlayed = true;
+  }
+
+  const timeout = setTimeout(() => {
+    // Set a timeout to call the desired function after the specified duration,
+    // if the event listeners for animationiteration() do not catch it.
+    console.log("Timeout reached, ending loading anim");
+    playLoadedAnim(gameLoadingContentImg, gameLoadInOverlay);
+  }, 3000); // ms
+
+  gameLoadingContentImg.addEventListener("animationiteration", function () {
+    playLoadedAnim(gameLoadingContentImg, gameLoadInOverlay);
+    clearTimeout(timeout); // Clear the timeout since the event fired
+  });
+  gameLoadingContentImg.addEventListener(
+    "webkitAnimationIteration", // For Safari pre-9 or other browser compatibility
+    function () {
+      playLoadedAnim(gameLoadingContentImg, gameLoadInOverlay);
+      clearTimeout(timeout); // Clear the timeout since the event fired
+    }
+  );
+}


### PR DESCRIPTION
Now can fall back to 3000ms timer if animation does not kick off, and uses another event that older browsers may use as well.