### PR TITLE
Cannot have 0 birth criteria

### DIFF
--- a/games/Game-Of-Life/js/settings-menu.js
+++ b/games/Game-Of-Life/js/settings-menu.js
@@ -326,7 +326,9 @@ export function addGameOfLifeSettings() {
   const reproductionSliderContainer = instantiateSlider(
     "Reproduction",
     TileGridAttrs.golRepoductionCritera,
-    "0",
+    // NOTE: cannot have 0 birth criteria, since the search
+    // has been optimized to never search dead cells without neighbors.
+    "1",
     "8",
     "1"
   );


### PR DESCRIPTION
-  This is because search has been optimized to never search dead cells without neighbors.